### PR TITLE
chore: remove explicit any types

### DIFF
--- a/tokeny-web/src/app/api/_utils.ts
+++ b/tokeny-web/src/app/api/_utils.ts
@@ -1,26 +1,45 @@
 import { auth } from "@clerk/nextjs/server";
 
-export async function callBackend(path: string, init?: RequestInit) {
-const apiBase = process.env.NEXT_PUBLIC_BACKEND_URL!;
+export type BackendError = Error & { status?: number; body?: unknown };
+
+export async function callBackend<T = unknown>(
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const apiBase = process.env.NEXT_PUBLIC_BACKEND_URL!;
   const { getToken } = await auth();
   const token = await getToken();
 
   const headers = new Headers(init?.headers);
   if (token) headers.set("Authorization", `Bearer ${token}`);
-  if (!headers.has("Content-Type") && init?.body) headers.set("Content-Type", "application/json");
+  if (!headers.has("Content-Type") && init?.body)
+    headers.set("Content-Type", "application/json");
 
-  const res = await fetch(`${apiBase}${path}`, { ...init, headers, cache: "no-store" });
+  const res = await fetch(`${apiBase}${path}`, {
+    ...init,
+    headers,
+    cache: "no-store",
+  });
 
   // prečítaj telo vždy, aj pri chybe
   const text = await res.text();
-  let json: any = null;
-  try { json = text ? JSON.parse(text) : null; } catch { json = { message: text }; }
+  let json: unknown = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = { message: text };
+  }
 
   if (!res.ok) {
-    const err: any = new Error(json?.message || `Backend ${res.status}`);
+    let message = `Backend ${res.status}`;
+    if (json && typeof json === "object" && "message" in json) {
+      const m = (json as Record<string, unknown>).message;
+      if (typeof m === "string") message = m;
+    }
+    const err = new Error(message) as BackendError;
     err.status = res.status;
     err.body = json;
     throw err;
   }
-  return json;
+  return json as T;
 }

--- a/tokeny-web/src/app/api/listings/route.ts
+++ b/tokeny-web/src/app/api/listings/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { callBackend } from "../_utils";
+import { callBackend, BackendError } from "../_utils";
 
 export async function GET() {
   try {
     const data = await callBackend("/listings", { method: "GET" });
     return NextResponse.json(data);
-  } catch (e: any) {
-    return NextResponse.json(e.body ?? { message: e.message }, { status: e.status ?? 500 });
+  } catch (e: unknown) {
+    const err = e as BackendError;
+    return NextResponse.json(err.body ?? { message: err.message }, { status: err.status ?? 500 });
   }
 }
 
@@ -18,7 +19,8 @@ export async function POST(req: NextRequest) {
       body: JSON.stringify(body),
     });
     return NextResponse.json(data);
-  } catch (e: any) {
-    return NextResponse.json(e.body ?? { message: e.message }, { status: e.status ?? 500 });
+  } catch (e: unknown) {
+    const err = e as BackendError;
+    return NextResponse.json(err.body ?? { message: err.message }, { status: err.status ?? 500 });
   }
 }

--- a/tokeny-web/src/app/api/market/create-checkout/route.ts
+++ b/tokeny-web/src/app/api/market/create-checkout/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { callBackend } from "../../_utils";
+import { callBackend, BackendError } from "../../_utils";
 
 export async function POST(req: NextRequest) {
   const { userId } = await auth();
@@ -13,7 +13,8 @@ export async function POST(req: NextRequest) {
       body: JSON.stringify(body),
     });
     return NextResponse.json(data);
-  } catch (e: any) {
-    return NextResponse.json(e.body ?? { message: e.message }, { status: e.status ?? 500 });
+  } catch (e: unknown) {
+    const err = e as BackendError;
+    return NextResponse.json(err.body ?? { message: err.message }, { status: err.status ?? 500 });
   }
 }

--- a/tokeny-web/src/app/api/wallet/me/route.ts
+++ b/tokeny-web/src/app/api/wallet/me/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { callBackend } from "../../_utils";
+import { callBackend, BackendError } from "../../_utils";
 
 export async function GET() {
   const { userId } = await auth();
@@ -9,7 +9,8 @@ export async function GET() {
   try {
     const data = await callBackend("/wallet/me", { method: "GET" });
     return NextResponse.json(data);
-  } catch (e: any) {
-    return NextResponse.json(e.body ?? { message: e.message }, { status: e.status ?? 500 });
+  } catch (e: unknown) {
+    const err = e as BackendError;
+    return NextResponse.json(err.body ?? { message: err.message }, { status: err.status ?? 500 });
   }
 }

--- a/tokeny-web/src/app/list/page.tsx
+++ b/tokeny-web/src/app/list/page.tsx
@@ -1,16 +1,29 @@
 "use client";
 import { useEffect, useState } from "react";
 
+interface Token {
+  id: string;
+  status: string;
+  remainingMinutes: number;
+}
+
 export default function ListPage() {
-  const [tokens, setTokens] = useState<any[]>([]);
+  const [tokens, setTokens] = useState<Token[]>([]);
   const [tokenId, setTokenId] = useState("");
   const [price, setPrice] = useState("15.00");
   const [msg, setMsg] = useState<string>();
 
   useEffect(() => {
-    fetch("/api/wallet/me").then(r => r.json()).then(d => {
-      setTokens((d.tokens||[]).filter((t:any)=>t.status==="owned" && t.remainingMinutes===60));
-    });
+    fetch("/api/wallet/me")
+      .then(r => r.json())
+      .then(d => {
+        const allTokens = (d.tokens ?? []) as Token[];
+        setTokens(
+          allTokens.filter(
+            t => t.status === "owned" && t.remainingMinutes === 60,
+          ),
+        );
+      });
   }, []);
 
   const submit = async () => {

--- a/tokeny-web/src/app/market/page.tsx
+++ b/tokeny-web/src/app/market/page.tsx
@@ -35,8 +35,9 @@ export default function MarketPage() {
         }
         const json = (await res.json()) as ApiListingsResponse;
         if (mounted) setListings(json);
-      } catch (e: any) {
-        if (mounted) setError(e?.message ?? 'Neznáma chyba');
+      } catch (e: unknown) {
+        if (mounted)
+          setError((e as Error)?.message ?? 'Neznáma chyba');
       }
     })();
     return () => { mounted = false; };
@@ -64,8 +65,8 @@ export default function MarketPage() {
       } else {
         alert('Server nevrátil URL pre checkout.');
       }
-    } catch (e: any) {
-      alert(e?.message ?? 'Chyba pri vytváraní checkoutu');
+    } catch (e: unknown) {
+      alert((e as Error)?.message ?? 'Chyba pri vytváraní checkoutu');
     } finally {
       setLoading(false);
     }
@@ -90,8 +91,8 @@ export default function MarketPage() {
       } else {
         alert('Server nevrátil URL pre checkout.');
       }
-    } catch (e: any) {
-      alert(e?.message ?? 'Chyba pri P2P checkoute');
+    } catch (e: unknown) {
+      alert((e as Error)?.message ?? 'Chyba pri P2P checkoute');
     } finally {
       setLoading(false);
     }

--- a/tokeny-web/src/app/page.tsx
+++ b/tokeny-web/src/app/page.tsx
@@ -14,7 +14,9 @@ export default function MarketPage() {
     try {
       const res = await fetch("/api/listings").then(r => r.json());
       setItems(res.items ?? []);
-    } catch (e:any) { setErr(e.message); }
+    } catch (e: unknown) {
+      setErr((e as Error).message);
+    }
     finally { setLoading(false); }
   };
 

--- a/tokeny-web/src/app/wallet/page.tsx
+++ b/tokeny-web/src/app/wallet/page.tsx
@@ -23,8 +23,8 @@ export default function Wallet() {
         }
         const json = (await res.json()) as ApiWalletMeResponse;
         if (mounted) setMe(json);
-      } catch (e: any) {
-        if (mounted) setError(e?.message ?? 'Neznáma chyba');
+      } catch (e: unknown) {
+        if (mounted) setError((e as Error)?.message ?? 'Neznáma chyba');
       }
     })();
     return () => { mounted = false; };


### PR DESCRIPTION
## Summary
- replace `any` usages with concrete types and safer error handling
- export reusable `BackendError` helper for API routes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdebacfa30832fb51c310161f72ac2